### PR TITLE
feat: add option to configure path prefix

### DIFF
--- a/cypherpunkpay/__init__.py
+++ b/cypherpunkpay/__init__.py
@@ -29,7 +29,7 @@ def main(global_config, **settings):
 
     # Routing
     path_prefix = App().config().path_prefix()
-    if path_prefix != '/':
+    if len(path_prefix) > 0:
         pyramid.add_route('get_root_not_prefixed', '/', request_method='GET')  # 302: / -> /path_prefix/
 
     pyramid.include(routing_config, route_prefix=path_prefix)
@@ -125,7 +125,7 @@ def routing_config(pyramid):
 
 def scan_views(pyramid):
     pyramid.scan('cypherpunkpay.web.views')
-    if App().config().path_prefix() != '/':
+    if len(App().config().path_prefix()) > 0:
         pyramid.scan('cypherpunkpay.web.views_prefix')
     if App().config().donations_enabled():
         pyramid.scan('cypherpunkpay.web.views_donations')

--- a/cypherpunkpay/__init__.py
+++ b/cypherpunkpay/__init__.py
@@ -16,8 +16,6 @@ from cypherpunkpay.jobs.job_scheduler import DummyJobScheduler
 from cypherpunkpay.prices.price_tickers import ExamplePriceTickers
 from cypherpunkpay.web.security.root_acl import RootACL
 
-CYPHERPUNKPAY_URL_PATH_PREFIX = '/cypherpunkpay'
-
 
 def main(global_config, **settings):
     """ This function instantiates real app singleton and returns a Pyramid WSGI web app.
@@ -30,8 +28,11 @@ def main(global_config, **settings):
     pyramid.include('pyramid_jinja2')
 
     # Routing
-    pyramid.add_route('get_root_not_prefixed', '/', request_method='GET')  # 302: / -> /CYPHERPUNKPAY_URL_PATH_PREFIX/
-    pyramid.include(routing_config, route_prefix=CYPHERPUNKPAY_URL_PATH_PREFIX)
+    path_prefix = App().config().path_prefix()
+    if path_prefix != '/':
+        pyramid.add_route('get_root_not_prefixed', '/', request_method='GET')  # 302: / -> /path_prefix/
+
+    pyramid.include(routing_config, route_prefix=path_prefix)
 
     # Authentication and Authorization
     configure_pyramid_authn_and_authz(pyramid)
@@ -67,7 +68,7 @@ def configure_pyramid_authn_and_authz(pyramid):
         hashalg='sha512',
         timeout=3600,
         reissue_time=60,
-        path=f'{CYPHERPUNKPAY_URL_PATH_PREFIX}/admin',
+        path=f'{App().config().path_prefix()}/admin',
         http_only=True,
         callback=(lambda user_login, request: ['group:admins'] if user_login == 'admin' else [])  # return groups for specific user
     )
@@ -124,6 +125,8 @@ def routing_config(pyramid):
 
 def scan_views(pyramid):
     pyramid.scan('cypherpunkpay.web.views')
+    if App().config().path_prefix() != '/':
+        pyramid.scan('cypherpunkpay.web.views_prefix')
     if App().config().donations_enabled():
         pyramid.scan('cypherpunkpay.web.views_donations')
     if App().config().admin_panel_enabled():

--- a/cypherpunkpay/config/config.py
+++ b/cypherpunkpay/config/config.py
@@ -28,6 +28,15 @@ class Config(object):
     def db_file_path(self) -> str:
         return self._dict.get('db_file_path')
 
+    def path_prefix(self) -> str:
+        path_prefix = self._dict.get('path_prefix', 'cypherpunkpay')
+        if path_prefix != '/':
+            if '/' in path_prefix:
+                log.error('Incorrect value for config entry path_prefix. It should not contain \'/\'.')
+                exit(1)
+            path_prefix = f'/{path_prefix}'
+        return path_prefix
+
     def btc_account_xpub(self) -> str:
         if self.btc_mainnet():
             return self._dict.get('btc_mainnet_account_xpub')

--- a/cypherpunkpay/config/config.py
+++ b/cypherpunkpay/config/config.py
@@ -30,11 +30,11 @@ class Config(object):
 
     def path_prefix(self) -> str:
         path_prefix = self._dict.get('path_prefix', 'cypherpunkpay')
-        if path_prefix != '/':
-            if '/' in path_prefix:
-                log.error('Incorrect value for config entry path_prefix. It should not contain \'/\'.')
-                exit(1)
-            path_prefix = f'/{path_prefix}'
+        if path_prefix == '/':
+            path_prefix = ''
+        if '/' in path_prefix:
+            log.error('Incorrect value for config entry path_prefix. It should not contain \'/\'.')
+            exit(1)
         return path_prefix
 
     def btc_account_xpub(self) -> str:

--- a/cypherpunkpay/config/cypherpunkpay_defaults.conf
+++ b/cypherpunkpay/config/cypherpunkpay_defaults.conf
@@ -98,3 +98,7 @@ charge_payment_timeout_in_minutes = 20
 # For Bitcoin, this is currently hardcoded as 2 confirmations.
 # If user paid with multiple transactions, then enough of them must be fully confirmed to cover the requested amount.
 charge_completion_timeout_in_hours = 48
+
+# All routes are served under the /cypherpunkpay/ prefix by default,
+# when set to / no prefix is used.
+path_prefix = cypherpunkpay

--- a/cypherpunkpay/web/views/root_view.py
+++ b/cypherpunkpay/web/views/root_view.py
@@ -4,13 +4,6 @@ from pyramid.httpexceptions import HTTPFound, HTTPNotFound
 from cypherpunkpay import App
 
 
-# This is for the not-prefixed top level root path:
-# /
-@view_config(route_name='get_root_not_prefixed')
-def get_root_not_prefixed(request):
-    return HTTPFound(request.route_url('get_root'))
-
-
 # This is for the prefixed root path:
 # /cypherpunkpay/
 @view_config(route_name='get_root')

--- a/cypherpunkpay/web/views_prefix/prefix_view.py
+++ b/cypherpunkpay/web/views_prefix/prefix_view.py
@@ -1,0 +1,9 @@
+from pyramid.httpexceptions import HTTPFound
+from pyramid.view import view_config
+
+
+# This is for the not-prefixed top level root path:
+# / redirecting to the prefixed root
+@view_config(route_name='get_root_not_prefixed')
+def get_root_not_prefixed(request):
+    return HTTPFound(request.route_url('get_root'))

--- a/test/acceptance/views/root_view_test.py
+++ b/test/acceptance/views/root_view_test.py
@@ -3,6 +3,10 @@ from test.acceptance.app_test_case import CypherpunkpayAppTestCase
 
 class RootViewTest(CypherpunkpayAppTestCase):
 
+    def test_get_not_prefixed_root(self):
+        res = self.webapp.get('/', status=302)
+        self.assertTrue(res.location.endswith('/cypherpunkpay/'))
+
     def test_get_root(self):
         res = self.webapp.get('/cypherpunkpay/', status=302)
         self.assertTrue(res.location.endswith('/donations'))


### PR DESCRIPTION
I tried to implement the removal of the path prefix myself.
When setting the new option `path_prefix` to `/` the prefix is removed. The default still is `cypherpunkpay`.
Looks like everything still works, but I was unsure how to write a test where the path_prefix is set to `/`.
Maybe you have an idea?

Closes #7 