### PR TITLE
Add option to disable tor for merchant callback url

### DIFF
--- a/cypherpunkpay/config/config.py
+++ b/cypherpunkpay/config/config.py
@@ -186,6 +186,9 @@ class Config(object):
     def merchant_enabled(self) -> bool:
         return self._dict.get('merchant_enabled', 'false') == 'true'
 
+    def merchant_use_tor(self) -> bool:
+        return self._dict.get('merchant_use_tor', 'true') != 'false'
+
     def payment_completed_notification_url(self) -> str:
         return self._dict.get('payment_completed_notification_url', None)
 

--- a/cypherpunkpay/config/cypherpunkpay_defaults.conf
+++ b/cypherpunkpay/config/cypherpunkpay_defaults.conf
@@ -61,6 +61,9 @@ merchant_enabled = false
 # You MUST validate order values in this handler to make sure user did not tamper with the submitted checkout form.
 #payment_completed_notification_url = https://YOURWEBSITE.COM/api/cypherpunkpay_payment_completed
 
+# Indicates if the callback to the payment_completed_notification_url should be routed over tor
+merchant_use_tor = true
+
 # A link back to merchant order status page.
 # User will be redirected here from CypherpunkPay in all scenarios (payment cancellation, payment completion, charge expiry, etc).
 # Use {merchant_order_id} to interpolate your order id.

--- a/cypherpunkpay/net/http_client/tor_http_client.py
+++ b/cypherpunkpay/net/http_client/tor_http_client.py
@@ -15,7 +15,7 @@ class TorHttpClient(BaseHttpClient):
 
     def get(self, url: str, privacy_context: str, headers: dict = None, set_tor_browser_headers: bool = True, verify=None):
         if is_local_network(url):
-            privacy_context = 'local_network'
+            privacy_context = BaseTorCircuits.LOCAL_NETWORK
         if privacy_context == BaseTorCircuits.SHARED_CIRCUIT_ID:
             privacy_context = get_domain_or_ip(url)
         session = self._tor_circuits.get_for(privacy_context)
@@ -34,7 +34,7 @@ class TorHttpClient(BaseHttpClient):
 
     def post(self, url: str, privacy_context: str, headers: dict = None, body: str = None, set_tor_browser_headers: bool = True, verify=None):
         if is_local_network(url):
-            privacy_context = 'local_network'
+            privacy_context = BaseTorCircuits.LOCAL_NETWORK
         if privacy_context == BaseTorCircuits.SHARED_CIRCUIT_ID:
             privacy_context = get_domain_or_ip(url)
         session = self._tor_circuits.get_for(privacy_context)

--- a/cypherpunkpay/net/tor_client/base_tor_circuits.py
+++ b/cypherpunkpay/net/tor_client/base_tor_circuits.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 class BaseTorCircuits(object):
 
     SHARED_CIRCUIT_ID = 'shared_circuit'  # for requests were linkability of actions does not matter (price tickers, blockchain height checking etc)
+    LOCAL_NETWORK = 'local_network'  # for requests where the target is in the local network or tor should not be used (merchant callback url)
 
     @abstractmethod
     def mark_as_broken(self, label):

--- a/cypherpunkpay/net/tor_client/official_tor_circuits.py
+++ b/cypherpunkpay/net/tor_client/official_tor_circuits.py
@@ -67,7 +67,7 @@ class OfficialTorCircuits(BaseTorCircuits):
 
     def _create_for(self, label):
         session = Session()
-        if label != 'local_network':
+        if label != BaseTorCircuits.LOCAL_NETWORK:
             socks5_proxy = f'socks5h://{label}:{label}@{self._config.tor_socks5_host()}:{self._config.tor_socks5_port()}'
             session.proxies = {'http': socks5_proxy, 'https': socks5_proxy}
         self._sessions[label] = session

--- a/cypherpunkpay/usecases/call_payment_completed_url_uc.py
+++ b/cypherpunkpay/usecases/call_payment_completed_url_uc.py
@@ -44,7 +44,7 @@ class CallPaymentCompletedUrlUC(UseCase):
 }}""".strip()
         privacy_context = BaseTorCircuits.SHARED_CIRCUIT_ID
         if not self._config.merchant_use_tor():
-            privacy_context = "local_network"
+            privacy_context = BaseTorCircuits.LOCAL_NETWORK
         try:
             response: Response = self._http_client.post(url, privacy_context=privacy_context, headers=headers, body=body)
         except requests.exceptions.RequestException as e:

--- a/test/network/net/tor_client/official_tor_circuits_test.py
+++ b/test/network/net/tor_client/official_tor_circuits_test.py
@@ -1,5 +1,8 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+import requests
+
+from cypherpunkpay.net.tor_client.base_tor_circuits import BaseTorCircuits
 from test.network.network_test_case import CypherpunkpayNetworkTestCase
 from cypherpunkpay.tools.safe_uid import SafeUid
 
@@ -74,6 +77,14 @@ class OfficialTorCircuitsTest(CypherpunkpayNetworkTestCase):
                     future.result()
                 except Exception as exc:
                     self.fail(f'Failure to get future.result() for future: {future.__dict__}')
+
+    def test_local_network_label_does_not_use_tor(self):
+        session = self.official_tor.get_for(BaseTorCircuits.LOCAL_NETWORK)
+
+        ip_disabled_tor = self.get_ip(session)
+        ip_clear = self.get_ip(requests.Session())
+
+        self.assertEqual(ip_disabled_tor, ip_clear)
 
     # @unittest.skip("TODO: needs to somehow change the circuit / label / socks5 user:pass")
     # def test_mark_as_broken_resets_tor_circuit(self):

--- a/test/unit/usecases/call_payment_completed_uc_test.py
+++ b/test/unit/usecases/call_payment_completed_uc_test.py
@@ -81,7 +81,7 @@ class CallPaymentCompletedUrlUCTest(CypherpunkpayDBTestCase):
         self.assertEqual('http://127.0.0.1:6543/cypherpunkpay/dummystore/cypherpunkpay_payment_completed', mock_http_client.url)
 
         # With local network privacy context
-        self.assertEqual('local_network', mock_http_client.privacy_context)
+        self.assertEqual(BaseTorCircuits.LOCAL_NETWORK, mock_http_client.privacy_context)
 
         # Has the right headers
         self.assertEqual('Bearer nsrzukv53xjhmw4w5ituyk5cre', mock_http_client.headers.get('Authorization'))

--- a/test/unit/usecases/call_payment_completed_uc_test.py
+++ b/test/unit/usecases/call_payment_completed_uc_test.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-
+from cypherpunkpay.net.tor_client.base_tor_circuits import BaseTorCircuits
 from test.unit.config.example_config import ExampleConfig
 from test.unit.db_test_case import CypherpunkpayDBTestCase
 from cypherpunkpay.models.charge import ExampleCharge
@@ -20,11 +20,13 @@ class StubResponse(object):
 class MockHttpClient(DummyHttpClient):
 
     url: str = None
+    privacy_context: str = None
     headers: dict = None
     body: str = None
 
     def post(self, url, privacy_context, headers: dict = None, body: str = None, set_tor_browser_headers: bool = True, verify=None):
         self.url = url
+        self.privacy_context = privacy_context
         self.headers = headers
         self.body = body
         return StubResponse()
@@ -41,6 +43,45 @@ class CallPaymentCompletedUrlUCTest(CypherpunkpayDBTestCase):
 
         # Calls the right URL
         self.assertEqual('http://127.0.0.1:6543/cypherpunkpay/dummystore/cypherpunkpay_payment_completed', mock_http_client.url)
+
+        # With tor privacy context
+        self.assertEqual(BaseTorCircuits.SHARED_CIRCUIT_ID, mock_http_client.privacy_context)
+
+        # Has the right headers
+        self.assertEqual('Bearer nsrzukv53xjhmw4w5ituyk5cre', mock_http_client.headers.get('Authorization'))
+        self.assertEqual('application/json', mock_http_client.headers.get('Content-Type'))
+
+        # Renders body correctly
+        body = mock_http_client.body
+        import json
+        parsed_body = json.loads(body)
+        self.assertTrue('untrusted' in parsed_body)
+        self.assertTrue('status' in parsed_body)
+        self.assertTrue('cc_total' in parsed_body)
+        self.assertTrue('cc_currency' in parsed_body)
+        self.assertTrue('"1234567890.00000001"' in body)
+        self.assertTrue('"1000.000000000001"' in body)
+
+        # Marks charge as notified
+        charge_reloaded = self.db.get_charge_by_uid('1')
+        self.assertIsNotNone(charge_reloaded.payment_completed_url_called_at)
+
+
+    def test_exec_without_tor(self):
+        charge = ExampleCharge.db_create(self.db, uid='1', total=Decimal('1234567890.00000001'), currency='usd', status='completed', merchant_order_id='ord-1', cc_total=Decimal('1000.000000000001'), cc_currency='btc')
+
+        mock_http_client = MockHttpClient()
+
+        config = ExampleConfig()
+        config._dict['merchant_use_tor'] = 'false'  # disable tor for merchant request
+
+        CallPaymentCompletedUrlUC(charge=charge, db=self.db, config=config, http_client=mock_http_client).exec()
+
+        # Calls the right URL
+        self.assertEqual('http://127.0.0.1:6543/cypherpunkpay/dummystore/cypherpunkpay_payment_completed', mock_http_client.url)
+
+        # With local network privacy context
+        self.assertEqual('local_network', mock_http_client.privacy_context)
 
         # Has the right headers
         self.assertEqual('Bearer nsrzukv53xjhmw4w5ituyk5cre', mock_http_client.headers.get('Authorization'))


### PR DESCRIPTION
Hi,
here is my proposal to solve issue #9.
It reuses the existing `local_network` privacy context to disable tor only for the merchant callback.

Closes #9 